### PR TITLE
yaml: pin layers

### DIFF
--- a/prod-devel-rcar4_new.yaml
+++ b/prod-devel-rcar4_new.yaml
@@ -27,19 +27,21 @@ variables:
 
 common_data:
   # Sources used by all yocto-based domains
+  # poky, meta-openembedded, meta-virtualization uses AGL verified revision.
+  # meta-xt-common pins to head of master.
   sources: &COMMON_SOURCES
     - type: git
       url: "git://git.yoctoproject.org/poky"
-      rev: scarthgap
+      rev: "72983ac391008ebceb45edc7a8f0f6d5f4fe715c"
     - type: git
       url: "git://git.openembedded.org/meta-openembedded"
-      rev: scarthgap
+      rev: "2759d8870ea387b76c902070bed8a6649ff47b56"
     - type: git
       url: "git://git.yoctoproject.org/meta-virtualization"
-      rev: scarthgap
+      rev: "f92518e20530edfebca45e4170e11460949a5303"
     - type: git
       url: "https://github.com/xen-troops/meta-xt-common.git"
-      rev: master
+      rev: "1164ec5123bfe687503b79126cbd2d86dfa39eaf"
 
   # Common configuration options for all yocto-based domains
   conf: &COMMON_CONF


### PR DESCRIPTION
The existing prod-devel-rcar4_new.yaml file refers to the HEAD of each layer.  As a result, it lost reproducibility.
I proposed pin layers.